### PR TITLE
Add node-latest environment

### DIFF
--- a/node-latest/.envrc
+++ b/node-latest/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/node-latest/flake.lock
+++ b/node-latest/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1689261696,
+        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/node-latest/flake.nix
+++ b/node-latest/flake.nix
@@ -7,7 +7,7 @@
     let
       overlays = [
         (final: prev: rec {
-          nodejs = prev.nodejs;
+          nodejs = prev.nodejs_20;
           pnpm = prev.nodePackages.pnpm;
           yarn = (prev.yarn.override { inherit nodejs; });
         })


### PR DESCRIPTION
This adds a separate node.js environment for the latest node version (20.X). It is otherwise an exact clone of the current node environment.

I also removed the explicit call to node 18 from the normal node flake, as the standard `nodejs` package in nixpkgs already tracks the LTS version. This will allow the flake to track LTS in perpetuity, at the cost of a bit of specificity in the flake. 