### PR TITLE
feature: add python venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ The sections below list what each template includes. In all cases, you're free t
 
 - [Python] 3.11.4
 - [pip] 23.0.1
-- [Virtualenv] 20.19.0
 
 ### [`ruby`](./ruby/)
 
@@ -355,7 +354,6 @@ All of the templates have only the root [flake](./flake.nix) as a flake input. T
 [texlive]: https://www.tug.org/texlive/
 [tflint]: https://github.com/terraform-linters/tflint
 [vault]: https://www.vaultproject.io
-[virtualenv]: https://pypi.org/project/virtualenv
 [vulnix]: https://github.com/flyingcircusio/vulnix
 [yarn]: https://yarnpkg.com
 [zig]: https://ziglang.org

--- a/python/flake.nix
+++ b/python/flake.nix
@@ -13,8 +13,12 @@
     {
       devShells = forEachSupportedSystem ({ pkgs }: {
         default = pkgs.mkShell {
-          packages = with pkgs; [ python311 virtualenv ] ++
-            (with pkgs.python311Packages; [ pip ]);
+          venvDir = "venv";
+          packages = with pkgs; [ python311 ] ++
+            (with pkgs.python311Packages; [ 
+              pip
+              venvShellHook 
+            ]);
         };
       });
     };


### PR DESCRIPTION
Hi @lucperkins I've needed to add venv to allow pip to work properly not sure if others have run into this. Seems a bit cleaner to me than running virtualenv separately.