### PR TITLE
Added OCaml to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -191,6 +191,11 @@
           description = "Node.js development environment";
         };
 
+        ocaml = {
+          path = ./ocaml;
+          description = "OCaml development environment";
+        };
+
         opa = {
           path = ./opa;
           description = "Open Policy Agent development environment";


### PR DESCRIPTION
Hey! I tried to use the OCaml template with `nix flake init`, and I noticed that all templates but the OCaml one were available. So I added it to the `flake.nix` file.