### PR TITLE
Update venv dir

### DIFF
--- a/python/flake.nix
+++ b/python/flake.nix
@@ -13,7 +13,7 @@
     {
       devShells = forEachSupportedSystem ({ pkgs }: {
         default = pkgs.mkShell {
-          venvDir = "venv";
+          venvDir = ".venv";
           packages = with pkgs; [ python311 ] ++
             (with pkgs.python311Packages; [ 
               pip


### PR DESCRIPTION
Replace the default venv directory with ".venv" which is the more conventional way. It's also the convention used in the official nix docs: https://nixos.org/manual/nixpkgs/stable/#how-to-consume-python-modules-using-pip-in-a-virtual-environment-like-i-am-used-to-on-other-operating-systems