### PR TITLE
Add nimble to the nim flake

### DIFF
--- a/nim/flake.nix
+++ b/nim/flake.nix
@@ -13,7 +13,7 @@
     {
       devShells = forEachSupportedSystem ({ pkgs }: {
         default = pkgs.mkShell {
-          packages = with pkgs; [ nim ];
+          packages = with pkgs; [ nim nimble ];
         };
       });
     };


### PR DESCRIPTION
Add nimble as a package to the nim flake template.

In the readme nimble is present, but it's not installed.