### PR TITLE
feat(zig): add `zls` and `lldb` to packages

### DIFF
--- a/zig/flake.nix
+++ b/zig/flake.nix
@@ -13,7 +13,7 @@
     {
       devShells = forEachSupportedSystem ({ pkgs }: {
         default = pkgs.mkShell {
-          packages = with pkgs; [ zig ];
+          packages = with pkgs; [ zig zls lldb ];
         };
       });
     };


### PR DESCRIPTION
[`zls`](https://github.com/zigtools/zls) is an LSP for zig.
[`lldb`](https://lldb.llvm.org/) is a debugger from the LLVM project that works with zig.