### PR TITLE
dvt: remove `nounset` bash opt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
 
             dvt = final.writeShellApplication {
               name = "dvt";
+              bashOptions = [ "errexit" "pipefail" ];
               text = ''
                 if [ -z "''${1}" ]; then
                   echo "no template specified"


### PR DESCRIPTION
`writeShellApplication` has `[ "errexit" "nounset" "pipefail" ]`
set for its `bashOptions` parameter. This sets these at the top
of every generated script.

The error message `"no template specified"` is never printed since
the script immediately dies because `${1}` isn't set and `nounset`
is enabled. Excluding the option from the script generation allows
the error message to print rather than just
`result/bin/dvt: line 6: 1: unbound variable` which isn't helpful.

<https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/trivial-builders/default.nix#L261>