### PR TITLE
java: enable Lombok integration

### DIFF
--- a/java/flake.nix
+++ b/java/flake.nix
@@ -18,6 +18,7 @@
           jdk = prev."jdk${toString javaVersion}";
           maven = prev.maven.override { jdk_headless = jdk; };
           gradle = prev.gradle.override { java = jdk; };
+          lombok = prev.lombok.override { inherit jdk; };
         };
 
       devShells = forEachSupportedSystem ({ pkgs }: {
@@ -31,6 +32,15 @@
             patchelf
             zlib
           ];
+
+          shellHook =
+            let
+              loadLombok = "-javaagent:${pkgs.lombok}/share/java/lombok.jar";
+              prev = "\${JAVA_TOOL_OPTIONS:+ $JAVA_TOOL_OPTIONS}";
+            in
+            ''
+              export JAVA_TOOL_OPTIONS="${loadLombok}${prev}"
+            '';
         };
       });
     };


### PR DESCRIPTION
> **NOTE**: The aim here is for integration with editors
> and language servers. This does not configure
> for build tools like Maven. Annotation processing
> must still be configured separately for compilation.

Additional JVM arguments can be specified through the
`JAVA_TOOL_OPTIONS` environment variable. For language
servers to be able to work with Lombok, the JVM must load
the `lombok.jar`. Lombok is packaged in nixpkgs, which provides
both a `java` wrapper for use with Lombok, as well as the JAR
itself on its own. This is what we care about. We can dynamically
make this accessible through the addition, whose path points to
the JAR that the Lombok package provides. Lombok is very useful, but can
be annoying to set-up when not working with a heavy IDE that abstracts
it all away. This eliminates the concern altogether, rather than having
to manually configure it for something like Neovim. It should just work
now.

It's a very lightweight addition that won't bloat. If the user
already is using the environment variable, the Lombok invocation will be
prepended rather than overriding the variable, hence why it is set in
`shellHook`, rather than simply as
`JAVA_TOOL_OPTIONS = "-javaagent:${pkgs.lombok}/share/java/lombok.jar"`.
The `lombok` package also has a gcroot tied to it, preventing it from
being garbage collected, just like everything else in `packages`.