### PR TITLE
Move flake scripts out of `overlays`; fix `format` script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,11 @@
           format = pkgs.writeShellApplication {
             name = "format";
             runtimeInputs = with pkgs; [ nixpkgs-fmt ];
-            text = "nixpkgs-fmt '**/*.nix'";
+            text = ''
+              shopt -s globstar
+
+              nixpkgs-fmt -- **/*.nix
+            '';
           };
 
           # only run this locally, as Actions will run out of disk space

--- a/flake.nix
+++ b/flake.nix
@@ -5,92 +5,97 @@
 
   outputs = { self, nixpkgs }:
     let
-      overlays = [
-        (final: prev:
-          let
-            getSystem = "SYSTEM=$(nix eval --impure --raw --expr 'builtins.currentSystem')";
-            forEachDir = exec: ''
-              for dir in */; do
-                (
-                  cd "''${dir}"
-
-                  ${exec}
-                )
-              done
-            '';
-          in
-          {
-            format = final.writeShellApplication {
-              name = "format";
-              runtimeInputs = with final; [ nixpkgs-fmt ];
-              text = "nixpkgs-fmt '**/*.nix'";
-            };
-
-            # only run this locally, as Actions will run out of disk space
-            build = final.writeShellApplication {
-              name = "build";
-              text = ''
-                ${getSystem}
-
-                ${forEachDir ''
-                  echo "building ''${dir}"
-                  nix build ".#devShells.''${SYSTEM}.default"
-                ''}
-              '';
-            };
-
-            check = final.writeShellApplication {
-              name = "check";
-              text = forEachDir ''
-                echo "checking ''${dir}"
-                nix flake check --all-systems --no-build
-              '';
-            };
-
-            dvt = final.writeShellApplication {
-              name = "dvt";
-              bashOptions = [ "errexit" "pipefail" ];
-              text = ''
-                if [ -z "''${1}" ]; then
-                  echo "no template specified"
-                  exit 1
-                fi
-
-                TEMPLATE=$1
-
-                nix \
-                  --experimental-features 'nix-command flakes' \
-                  flake init \
-                  --template \
-                  "github:the-nix-way/dev-templates#''${TEMPLATE}"
-              '';
-            };
-
-            update = final.writeShellApplication {
-              name = "update";
-              text = forEachDir ''
-                echo "updating ''${dir}"
-                nix flake update
-              '';
-            };
-          })
-      ];
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
-        pkgs = import nixpkgs { inherit overlays system; };
+        pkgs = nixpkgs.legacyPackages.${system};
       });
+
+      scriptDrvs = forEachSupportedSystem ({ pkgs }:
+        let
+          getSystem = "SYSTEM=$(nix eval --impure --raw --expr 'builtins.currentSystem')";
+          forEachDir = exec: ''
+            for dir in */; do
+              (
+                cd "''${dir}"
+
+                ${exec}
+              )
+            done
+          '';
+        in
+        {
+          format = pkgs.writeShellApplication {
+            name = "format";
+            runtimeInputs = with pkgs; [ nixpkgs-fmt ];
+            text = "nixpkgs-fmt '**/*.nix'";
+          };
+
+          # only run this locally, as Actions will run out of disk space
+          build = pkgs.writeShellApplication {
+            name = "build";
+            text = ''
+              ${getSystem}
+
+              ${forEachDir ''
+                echo "building ''${dir}"
+                nix build ".#devShells.''${SYSTEM}.default"
+              ''}
+            '';
+          };
+
+          check = pkgs.writeShellApplication {
+            name = "check";
+            text = forEachDir ''
+              echo "checking ''${dir}"
+              nix flake check --all-systems --no-build
+            '';
+          };
+
+          update = pkgs.writeShellApplication {
+            name = "update";
+            text = forEachDir ''
+              echo "updating ''${dir}"
+              nix flake update
+            '';
+          };
+        });
     in
     {
       devShells = forEachSupportedSystem ({ pkgs }: {
         default = pkgs.mkShell {
-          packages = with pkgs; [ build check format update nixpkgs-fmt ];
+          packages =
+            with scriptDrvs.${pkgs.system}; [
+              build
+              check
+              format
+              update
+            ] ++ [ pkgs.nixpkgs-fmt ];
         };
       });
 
-      packages = forEachSupportedSystem ({ pkgs }: rec {
-        default = dvt;
-        inherit (pkgs) dvt;
-      });
+      packages = forEachSupportedSystem ({ pkgs }:
+        rec {
+          default = dvt;
+          dvt = pkgs.writeShellApplication {
+            name = "dvt";
+            bashOptions = [ "errexit" "pipefail" ];
+            text = ''
+              if [ -z "''${1}" ]; then
+                echo "no template specified"
+                exit 1
+              fi
+
+              TEMPLATE=$1
+
+              nix \
+                --experimental-features 'nix-command flakes' \
+                flake init \
+                --template \
+                "github:the-nix-way/dev-templates#''${TEMPLATE}"
+            '';
+          };
+        }
+      );
     }
 
     //


### PR DESCRIPTION
## Move flake scripts out from `overlays`
The flake scripts themselves are fine and do presently work with the current merge through the use of overlays.

As I've learnt, this can be problematic however.
View the following for reference of what is explained below:
<https://discourse.nixos.org/t/why-does-overlaying-check-with-nodepackages-prettier-cause-a-massive-rebuild/55810>

When overlaying packages, if there is an existing package with the same name, this should either be avoided altogether or done with consideration to ensure it is a proper replacement. `check` for example, is an existing package in `nixpkgs`.
Here a `check` overlay is defined, substituting it with the `check` script derivation defined in `flake.nix`. With he current batch of packages in the environment, nothing is affected fortunately. However, adding `nodePackages.prettier` will cause a massive rebuild by Nix as there are many packages that are dependent on the original `check` package. Nix, doing the right thing, works to build what it needs. Although the final result will be what is expected, this is more a side effect.

What is the point being argued here if the current implementation is working?

The big point is that this is a bad practice, since this is not what overlays were meant for. The same can be achieved by defining the packages anywhere else, and then referencing them as needed, rather than through overlays, which can cause unintended side effects, such as the one described.

Considering this is a repo that is very helpful particularly for beginners that may be new or not as experienced with the Nix ecosystem, presenting potential beginners to incorrect usage of overlays, can lead them to doing the same. Hence, the change here would be better in line with correct implementation. Someone visiting the repo hoping to implement helper script packages like here, could then reference this more "correct" implementation. Such as myself, who ended up following the previous implementation until I encountered the side effect explained in the post linked above.

The script derivations can really be defined anywhere, such as in a simple `let` binding, which I've done here. They will have gcroots linked so they won't be garbage collected, just like in the previous implementation.

In the end, the resulting behavior remains entirely the same, just the implementation is corrected to avoid side effects and serveas an example of better practices.

This is to claim any sort of superiority or anything regarding the previous implementation, rather I was hoping to improve this to save others the headache of going down the rabbit hole that I myself did, as expressed in the linked post.

*Many thanks.*

## Fix `format` script

The previous script was failing, as it was supposed to. It was trying to match a file named `'**/*.nix'`, rather
than expanding the intended pattern.

Bash doesn't do shell expansion inside of quotes. It must be written unquoted, else `*` and other special characters are treated literally.

`'**/*.nix'` -> `**/*.nix`

The new version will expand correctly.

Additionally, I've enabled `globstar` to make the expansion match all files ending with `.nix` recursively, including the top level. Without this, the pattern will only match up one level.

`globstar` is documented here:
<https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html>