### PR TITLE
java: actually inherit `jdk` overlay

### DIFF
--- a/java/flake.nix
+++ b/java/flake.nix
@@ -19,6 +19,7 @@
           jdk = prev."jdk${toString javaVersion}";
         in
         {
+          inherit jdk;
           maven = prev.maven.override { jdk_headless = jdk; };
           gradle = prev.gradle.override { java = jdk; };
           lombok = prev.lombok.override { inherit jdk; };


### PR DESCRIPTION
When this flake was last updated, the overlay were
changed a bit. `jdk` was removed from the overlay
accidentally. It was just re-added to have the
entire stack match the set Java version.
