### PR TITLE
Add Tauri flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Once your preferred template has been initialized, you can use the provided shel
 | [Shell]                          | [`shell`](./shell/)                   |
 | [SWI-prolog]                     | [`swi-prolog`](./swi-prolog/)         |
 | [Swift]                          | [`swift`](./swift)                    |
+| [Tauri]                          | [`Tauri`](./tauri)                    |
 | [Vlang]                          | [`vlang`](./vlang/)                   |
 | [Zig]                            | [`zig`](./zig/)                       |
 
@@ -305,6 +306,10 @@ A dev template that's fully customizable.
 
 - [Swift] 5.8
 - [sourcekit-lsp]
+
+### [`tauri`](./tauri/)
+
+<I have left this empty as I really doubt that my flake is any good and will need a lot of playing with to get it up to standard>
 
 ### [`vlang`](./vlang/)
 

--- a/tauri/.envrc
+++ b/tauri/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/tauri/flake.lock
+++ b/tauri/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1739400328,
+        "narHash": "sha256-c1VQqfpDPCyYVG7tEznItKHPAH86Fy/DdVO099jr6kY=",
+        "owner": "fractal-tess",
+        "repo": "nix-systems",
+        "rev": "81943977cfc44db116baf753f7fd9655ff5271cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fractal-tess",
+        "repo": "nix-systems",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tauri/flake.nix
+++ b/tauri/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Tauri development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:fractal-tess/nix-systems";
+  };
+
+  outputs =
+    { nixpkgs, systems, ... }@inputs:
+    let
+      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      packages =
+        pkgs: with pkgs; [
+          pkg-config
+          gobject-introspection
+          gtk3
+          pango
+          cairo
+          gdk-pixbuf
+          glib
+          libsoup_3
+          webkitgtk_4_1
+          atkmm
+          mold
+
+          cargo
+          rustc
+          rustfmt
+
+          mold
+          clang
+
+          nodejs_22
+          pnpm
+          nodePackages."npm-check-updates"
+          npkill
+        ];
+    in
+    {
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          buildInputs = packages pkgs;
+        };
+      });
+    };
+}


### PR DESCRIPTION
This does function with the current version Tauri, but it probably needs some edits.

## Why a Tauri flake?
Tauri requires the Node.js set of dev tools as well as the Rust ones. It also has some packages specific to itself, this is documented in [the Tauri docs](https://v2.tauri.app/start/prerequisites/#linux), but it is as a devshell not a flake.

## Why draft?
I'm almost entirely sure that this will need some edits that are beyond my skill set, so I am putting this here to see if someone more skilled can finish the flake.

Closes #81 