### PR TITLE
Remove `rust-toolchain` `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Once your preferred template has been initialized, you can use the provided shel
 | [R]                              | [`r`](./r/)                           |
 | [Ruby]                           | [`ruby`](./ruby/)                     |
 | [Rust]                           | [`rust`](./rust/)                     |
-| [Rust from toolchain file][rust] | [`rust-toolchain`](./rust-toolchain/) |
 | [Scala]                          | [`scala`](./scala/)                   |
 | Shell                            | [`shell`](./shell/)                   |
 | [SWI-prolog]                     | [`swi-prolog`](./swi-prolog/)         |


### PR DESCRIPTION
`rust-toolchain` was removed in the following commit: https://github.com/the-nix-way/dev-templates/commit/769635474d7db73bbca7bc979829ba8c398a886d#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R300

Update README to reflect this.