### PR TITLE
omit go version in flake description

### DIFF
--- a/go/flake.nix
+++ b/go/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A Nix-flake-based Go 1.22 development environment";
+  description = "A Nix-flake-based Go development environment";
 
   inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
 


### PR DESCRIPTION
none of the other flakes specify the version in description and it's easy to forget to update the description (as has happened already).