### PR TITLE
Revert "Remove csharp template"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Once your preferred template has been initialized, you can use the provided shel
 | [Bun]                    | [`bun`](./bun/)               |
 | [C] / [C++]              | [`c-cpp`](./c-cpp/)           |
 | [Clojure]                | [`clojure`](./clojure/)       |
+| [C#][csharp]             | [`csharp`](./csharp/)         |
 | [Cue]                    | [`cue`](./cue/)               |
 | [Deno]                   | [`deno`](./deno)              |
 | [Dhall]                  | [`dhall`](./dhall/)           |
@@ -98,6 +99,13 @@ The sections below list what each template includes. In all cases, you're free t
 - [Clojure]
 - [Boot]
 - [Leiningen]
+
+### [`csharp`](./csharp/)
+
+- [dotnet]
+- [omnisharp-roslyn]
+- [Mono]
+- [msbuild]
 
 ### [`cue`](./cue/)
 
@@ -337,6 +345,7 @@ A dev template that's fully customizable.
 [conan]: https://conan.io
 [conftest]: https://conftest.dev
 [cppcheck]: http://cppcheck.sourceforge.net
+[csharp]: https://dotnet.microsoft.com/en-us/languages/csharp
 [cue]: https://cuelang.org
 [damon]: https://github.com/hashicorp/damon
 [deno]: https://deno.com

--- a/csharp/.envrc
+++ b/csharp/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/csharp/flake.nix
+++ b/csharp/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "A Nix-flake-based C# development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+    in
+    {
+      devShells = forEachSupportedSystem (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              #dotnet-sdk_8
+              dotnet-sdk_10
+              omnisharp-roslyn
+              mono
+              msbuild
+            ];
+          };
+        }
+      );
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,11 @@
             description = "Clojure development environment";
           };
 
+          csharp = {
+            path = ./csharp;
+            description = "C# development environment";
+          };
+
           cue = {
             path = ./cue;
             description = "Cue development environment";


### PR DESCRIPTION
This reverts commit 5c03fd99c616edaed8e7eab6ede15cdf061ce089. #77 
Because dotnet-sdk_8 is now not marked as insecure.

