### PR TITLE
Remove node2nix and update pnpm reference

### DIFF
--- a/node/flake.nix
+++ b/node/flake.nix
@@ -36,9 +36,8 @@
         {
           default = pkgs.mkShellNoCC {
             packages = with pkgs; [
-              node2nix
               nodejs
-              nodePackages.pnpm
+              pnpm
               yarn
               self.formatter.${system}
             ];


### PR DESCRIPTION
It seems like `node2nix` has been removed/deprecated. This is just a minor update to the development shell configuration in `node/flake.nix`, specifically adjusting the package list for the shell environment.

- Replaces `nodePackages.pnpm` with `pnpm` and removes `node2nix` from the shell packages.

---

Error:
```nix
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/anvdcc2arw7kqrvwnidvhw6ypkkvws68-source/pkgs/stdenv/generic/make-derivation.nix:541:11

       … while evaluating attribute 'nativeBuildInputs' of derivation 'nix-shell'
         at /nix/store/anvdcc2arw7kqrvwnidvhw6ypkkvws68-source/pkgs/stdenv/generic/make-derivation.nix:590:11:
          589|           depsBuildBuild = elemAt (elemAt dependencies 0) 0;
          590|           nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
             |           ^
          591|           depsBuildTarget = elemAt (elemAt dependencies 0) 2;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: node2nix has been removed because it was only used to maintain the now-removed nodePackages set. Use the newer builders in nixpkgs instead, such as buildNpmPackage
direnv: nix-direnv: Evaluating current devShell failed. Falling back to previous environment!
direnv: export +AR +AS +CC +CONFIG_SHELL +CXX +HOST_PATH +IN_NIX_SHELL +LD +NIX_BINTOOLS +NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu +NIX_BUILD_CORES +NIX_CC +NIX_CC_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu +NIX_CFLAGS_COMPILE +NIX_DIRENV_DID_FALLBACK +NIX_ENFORCE_NO_NATIVE +NIX_HARDENING_ENABLE +NIX_LDFLAGS +NIX_STORE +NM +OBJCOPY +OBJDUMP +RANLIB +READELF +SIZE +SOURCE_DATE_EPOCH +STRINGS +STRIP +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~PATH ~XDG_DATA_DIRS
```